### PR TITLE
Add overflow hidden to body (#61)

### DIFF
--- a/flip-switch/index.html
+++ b/flip-switch/index.html
@@ -30,6 +30,7 @@ limitations under the License.
       display: flex;
       align-items: center;
       justify-content: center;
+      overflow: hidden;
     }
 
     flip-switch.modal {


### PR DESCRIPTION
Add overflow: hidden to body to prevent the ripple from displaying scrollbars. As the ripple is bigger than the body when it is expanded it is overflowing the body.